### PR TITLE
Fix inspector overlay highlight leak

### DIFF
--- a/content_scripts/inspector.js
+++ b/content_scripts/inspector.js
@@ -123,6 +123,8 @@ async function createSelectorOverlay() {
   selectorOverlay.querySelector('#tp-close-overlay').onclick = () => {
     selectorOverlay.remove();
     selectorOverlay = null;
+    // Remove any leftover highlight when the overlay is closed
+    removeHighlightBox();
   };
 }
 


### PR DESCRIPTION
## Summary
- clean up highlight box when closing the inspector overlay

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684309e798d08326906c755fb50a0202